### PR TITLE
Fade out, when selecting from calendar popup

### DIFF
--- a/build/jquery.continuous-calendar-latest.js
+++ b/build/jquery.continuous-calendar-latest.js
@@ -980,6 +980,7 @@ DateRange.rangeWithMinimumSize = function(oldRange, minimumSize, disableWeekends
         disabledDates: null,
         minimumRange: -1,
         selectWeek: false,
+        fadeOutDuration: 0,
         callback: function() {
         }
       }
@@ -1026,6 +1027,7 @@ DateRange.rangeWithMinimumSize = function(oldRange, minimumSize, disableWeekends
         var rangeStart = params.firstDate ? Date.parseDate(params.firstDate, params.locale.shortDateFormat) : firstWeekdayOfGivenDate.plusDays(-(params.weeksBefore * 7))
         var rangeEnd = params.lastDate ? Date.parseDate(params.lastDate, params.locale.shortDateFormat) : firstWeekdayOfGivenDate.plusDays(params.weeksAfter * 7 + 6)
         params.disabledDates = params.disabledDates ? parseDisabledDates(params.disabledDates) : {}
+        params.fadeOutDuration = parseInt(params.fadeOutDuration)
         calendarRange = new DateRange(rangeStart, rangeEnd)
         var headerTable = $('<table>').addClass('calendarHeader').append(headerRow())
         bodyTable = $('<table>').addClass('calendarBody').append(calendarBody())
@@ -1194,7 +1196,12 @@ DateRange.rangeWithMinimumSize = function(oldRange, minimumSize, disableWeekends
       }
 
       function toggleCalendar() {
-        calendarContainer.toggle()
+        if(calendarContainer.is(':visible')) {
+            console.log(params.fadeOutDuration)
+            calendarContainer.fadeOut(params.fadeOutDuration)
+        } else {
+            calendarContainer.show()
+        }
         if(beforeFirstOpening) {
           calculateCellHeight()
           setYearLabel()

--- a/src/main/jquery.continuous-calendar.js
+++ b/src/main/jquery.continuous-calendar.js
@@ -35,6 +35,7 @@
         disabledDates: null,
         minimumRange: -1,
         selectWeek: false,
+        fadeOutDuration: 0,
         callback: function() {
         }
       }
@@ -81,6 +82,7 @@
         var rangeStart = params.firstDate ? Date.parseDate(params.firstDate, params.locale.shortDateFormat) : firstWeekdayOfGivenDate.plusDays(-(params.weeksBefore * 7))
         var rangeEnd = params.lastDate ? Date.parseDate(params.lastDate, params.locale.shortDateFormat) : firstWeekdayOfGivenDate.plusDays(params.weeksAfter * 7 + 6)
         params.disabledDates = params.disabledDates ? parseDisabledDates(params.disabledDates) : {}
+        params.fadeOutDuration = parseInt(params.fadeOutDuration)
         calendarRange = new DateRange(rangeStart, rangeEnd)
         var headerTable = $('<table>').addClass('calendarHeader').append(headerRow())
         bodyTable = $('<table>').addClass('calendarBody').append(calendarBody())
@@ -249,7 +251,12 @@
       }
 
       function toggleCalendar() {
-        calendarContainer.toggle()
+        if(calendarContainer.is(':visible')) {
+            console.log(params.fadeOutDuration)
+            calendarContainer.fadeOut(params.fadeOutDuration)
+        } else {
+            calendarContainer.show()
+        }
         if(beforeFirstOpening) {
           calculateCellHeight()
           setYearLabel()

--- a/src/playground.html
+++ b/src/playground.html
@@ -62,6 +62,7 @@
     </div>
     <label class="row"><span class="label">minimumRange</span><input type="text" id="minimumRange" value="-1" class="number"/></label>
     <label class="row"><span class="label">disabledDates</span><input type="text" id="disabledDates" class="date"/></label>
+    <label class="row"><span class="label">fadeOutDuration</span><input type="text" id="fadeOutDuration" value="0" class="number"/></label>
     <label class="row"><input type="checkbox" value="" id="isPopup"/><span class="label">isPopup</span></label>
     <label class="row"><input type="checkbox" value="" id="selectToday"/><span class="label">selectToday</span></label>
     <label class="row"><input type="checkbox" value="" id="disableWeekends"/><span class="label">disableWeekends</span></label>
@@ -95,7 +96,7 @@
       container.append('<input type="hidden" class="startDate" /><input type="hidden" class="endDate"/>')
     }
     $('body').append(container)
-    var optionsList = [ 'selectToday', 'disableWeekends', 'isPopup', 'weeksBefore', 'weeksAfter', 'firstDate', 'lastDate', 'minimumRange', 'selectWeek', 'disabledDates' ]
+    var optionsList = [ 'selectToday', 'disableWeekends', 'isPopup', 'weeksBefore', 'weeksAfter', 'firstDate', 'lastDate', 'minimumRange', 'selectWeek', 'disabledDates', 'fadeOutDuration' ]
     var options = {}
     for(var i = 0; i < optionsList.length; i++)
       options[optionsList[i]] = valueOf(optionsList[i])


### PR DESCRIPTION
Use fade out instead hiding, so the user can
confirm his selection more visually.

fadeOutDuration determines how fast the fade out
is performed. Defaults to zero i.e. hiding.
