### PR TITLE
topic/fade_scroll

### DIFF
--- a/build/jquery.continuous-calendar-latest.js
+++ b/build/jquery.continuous-calendar-latest.js
@@ -1197,10 +1197,10 @@ DateRange.rangeWithMinimumSize = function(oldRange, minimumSize, disableWeekends
 
       function toggleCalendar() {
         if(calendarContainer.is(':visible')) {
-            calendarContainer.fadeOut(params.fadeOutDuration)
-        } else {
-            calendarContainer.show()
+          calendarContainer.fadeOut(params.fadeOutDuration)
+          return false
         }
+        calendarContainer.show()
         if(beforeFirstOpening) {
           calculateCellHeight()
           setYearLabel()

--- a/src/main/jquery.continuous-calendar.js
+++ b/src/main/jquery.continuous-calendar.js
@@ -252,10 +252,10 @@
 
       function toggleCalendar() {
         if(calendarContainer.is(':visible')) {
-            calendarContainer.fadeOut(params.fadeOutDuration)
-        } else {
-            calendarContainer.show()
+          calendarContainer.fadeOut(params.fadeOutDuration)
+          return false
         }
+        calendarContainer.show()
         if(beforeFirstOpening) {
           calculateCellHeight()
           setYearLabel()


### PR DESCRIPTION
Previously, when `fadeOutDuration` was greater than zero and the calendar contained many weeks, jarringly `scrollToSelection()` was invoked while the element was fading out. Now `scrollToSelection()` is only invoked when the element is made visible.
