### PR TITLE
Handle dot as escaped in regexp formatter

### DIFF
--- a/src/main/date-functions.js
+++ b/src/main/date-functions.js
@@ -460,6 +460,10 @@ Date.formatCodeToRegex = function(character, currentGroup) {
       return {g:0,
         c:null,
         s:"[+-]\\d{1,5}"}
+    case ".":
+      return {g:0,
+        c:null,
+        s:"\\."}
     default:
       return {g:0,
         c:null,


### PR DESCRIPTION
The dot character was unescaped and thus matched every character when checking for dates with a dot in the format
