### PR TITLE
Fixes issue #35, with tests showing original failure and patch fix

### DIFF
--- a/src/main/jquery.continuous-calendar.js
+++ b/src/main/jquery.continuous-calendar.js
@@ -551,7 +551,7 @@
 
       function isEnabled(elem) { return !$(elem).hasClass('disabled') }
 
-      function getElemDate(elem) { return dateCellDates[$(elem).attr('date-cell-index')] }
+      function getElemDate(elem) { return dateCellDates[$(elem).closest('[date-cell-index]').attr('date-cell-index')] }
 
       function getDateCell(index) { return $(dateCells[index]) }
 

--- a/src/test/jquery.continuous-calendar-test.js
+++ b/src/test/jquery.continuous-calendar-test.js
@@ -194,6 +194,35 @@ describe('calendar events', function() {
     expect(cal().find('.rangeLengthLabel')).toHaveText('15 Days')
   })
 
+
+
+  it('mouse click and drag can start or end on current date', function() {
+    var d_today = new Date(),
+      s_today   = (d_today.getMonth() + 1) + '/' + d_today.getDate() + '/' + d_today.getFullYear(),
+      d_start   = new Date(d_today.setDate(d_today.getDate() - 7)),
+      s_start   = (d_start.getMonth() + 1) + '/' + d_start.getDate() + '/' + d_start.getFullYear(),
+      d_end     = new Date(d_today.setDate(d_today.getDate() + 14)),
+      s_end     = (d_end.getMonth() + 1) + '/' + d_end.getDate() + '/' + d_end.getFullYear()
+    d_today = new Date();
+    createCalendarWithNoRange(s_start, s_end)
+    startTimer()
+    dragDatesSlowly(d_today.getDate(), d_end.getDate())
+    var duration = stopTimer()
+    expect(cal().find('.selected').size()).toEqual(8, '(' + duration + ' ms)')
+    expect(startFieldValue()).toEqual(s_today)
+    expect(endFieldValue()).toEqual(s_end)
+    expect(cal().find('.rangeLengthLabel')).toHaveText('8 Days')
+    startTimer()
+    dragDatesSlowly(d_start.getDate(), d_today.getDate())
+    var duration = stopTimer()
+    expect(cal().find('.selected').size()).toEqual(8, '(' + duration + ' ms)')
+    expect(startFieldValue()).toEqual(s_start)
+    expect(endFieldValue()).toEqual(s_today)
+    expect(cal().find('.rangeLengthLabel')).toHaveText('8 Days')
+  })
+
+
+
   it('mouse click and drag works with no initial selection', function() {
     createCalendarFields({startDate: '', endDate: ''}).continuousCalendar({firstDate: '1/1/2009', lastDate: '2/1/2009'})
     dragDates(22, 23)

--- a/src/test/test-functions.js
+++ b/src/test/test-functions.js
@@ -83,6 +83,10 @@ function createCalendarWithOneWeek() {
   createCalendarFields({startDate:'4/30/2008'}).continuousCalendar({weeksBefore: 0,weeksAfter: 0})
 }
 
+function createCalendarWithNoRange(start, end) {
+  createCalendarFields({startDate: '', endDate: ''}).continuousCalendar({firstDate: start, lastDate: end})
+}
+
 function createRangeCalendarWithFiveWeeks() {
   createCalendarFields({startDate: '4/29/2009', endDate: '5/5/2009'}).continuousCalendar({firstDate:'4/15/2009',lastDate:'5/12/2009'})
 }
@@ -121,7 +125,10 @@ function clickOnDate(date) {
 }
 
 function mouseEventOnDay(eventType, date, options) {
-  mouseEvent(eventType, cal().find('.date').withText(date), options);
+  var elem = cal().find('.date div').withText(date).length === 0 ?
+    cal().find('.date').withText(date) :
+    cal().find('.date div').withText(date);
+  mouseEvent(eventType, elem, options);
 }
 
 function mouseDownOnDay(date) {


### PR DESCRIPTION
mousedown, mouseover, mouseup events return the current
date's table cell's inner div, which does not have a mouse
event bound to it, so was throwing an uncaught exception.
this patch include a test and modifies the test utilities to
return the div, so that the test will fail without the patch.
