### PR TITLE
Add selection setting through field(s)

### DIFF
--- a/src/main/RangeEvents.js
+++ b/src/main/RangeEvents.js
@@ -22,6 +22,7 @@ define(function(require) {
       addRangeLengthLabel : addRangeLengthLabel,
       addEndDateLabel     : addEndDateLabel,
       addDateClearingLabel: addDateClearingLabel,
+      setSelection        : setSelection,
       performTrigger      : performTrigger
     }
 
@@ -30,6 +31,11 @@ define(function(require) {
       oldSelection = selection.clone()
       initRangeCalendarEvents(container, calendarBody.bodyTable)
       drawSelection()
+    }
+
+    function setSelection(start, end) {
+      if (start && end) selection = new DateRange(start, end)
+      mouseUp()
     }
 
     function addRangeLengthLabel() {

--- a/src/main/SingleDateEvents.js
+++ b/src/main/SingleDateEvents.js
@@ -9,22 +9,41 @@ define(function(require) {
       addRangeLengthLabel : $.noop,
       addEndDateLabel     : $.noop,
       addDateClearingLabel: addDateClearingLabel,
+      setSelection        : setSelection,
       performTrigger      : performTrigger
     }
 
     function showInitialSelection() {
       if(startDate) {
-        setDateLabel(DateFormat.format(startDate, locale.weekDateFormat, locale))
+        setFieldValues(startDate)
         $('.clearDates', container).show()
       }
     }
 
     function initEvents() {
       initSingleDateCalendarEvents()
-      var selectedDateKey = startDate && DateFormat.format(startDate, 'Ymd', locale)
+      setSelection(fieldDate(params.startField) || startDate)
+    }
+
+    function fieldDate(field) { return field.length > 0 && field.val().length > 0 ? DateFormat.parse(field.val()) : null }
+
+    function setSelection(date) {
+      var selectedDateKey = date && DateFormat.format(date, 'Ymd', locale)
       if(selectedDateKey in calendarBody.dateCellMap) {
-        calendarBody.getDateCell(calendarBody.dateCellMap[selectedDateKey]).addClass('selected')
+        setSelectedDate(date, calendarBody.getDateCell(calendarBody.dateCellMap[selectedDateKey]))
       }
+    }
+
+    function setSelectedDate(date, cell) {
+      $('td.selected', container).removeClass('selected')
+      cell.addClass('selected')
+      setFieldValues(date)
+    }
+
+    function setFieldValues(date) {
+      container.data('calendarRange', date)
+      params.startField.val(DateFormat.shortDateFormat(date, locale))
+      setDateLabel(DateFormat.format(date, locale.weekDateFormat, locale))
     }
 
     function addDateClearingLabel() {
@@ -45,11 +64,8 @@ define(function(require) {
       $('.date', container).bind('click', function() {
         var dateCell = $(this)
         if (!dateCell.hasClass('disabled')) {
-          $('td.selected', container).removeClass('selected')
-          dateCell.addClass('selected')
           var selectedDate = getElemDate(dateCell.get(0));
-          params.startField.val(DateFormat.shortDateFormat(selectedDate, locale))
-          setDateLabel(DateFormat.format(selectedDate, locale.weekDateFormat, locale))
+          setSelectedDate(selectedDate, dateCell)
           popupBehavior.close(this)
           executeCallback(selectedDate)
         }

--- a/src/main/jquery.continuousCalendar.js
+++ b/src/main/jquery.continuousCalendar.js
@@ -169,6 +169,7 @@ define(function(require) {
               setYearLabel()
               beforeFirstOpening = false
             }
+            dateBehavior.setSelection(fieldDate(params.startField), fieldDate(params.endField))
             scrollToSelection()
             $(document).bind('click.continuousCalendar', toggleCalendar)
 

--- a/src/test/jquery.continuousCalendar.spec.js
+++ b/src/test/jquery.continuousCalendar.spec.js
@@ -171,6 +171,16 @@ define(function(require) {
         createCalendarWithNoRange('7/14/2013', '7/26/2013')
         dragOutsideCalendar(15)
       })
+
+      it('changes its selection when opening according to start and end fields', function() {
+        createPopupRangeCalendar('12/15/2013', '2/22/2014')
+        setStartFieldValue('1/14/2014')
+        setEndFieldValue('1/16/2014')
+        cal().find('.calendarIcon').click()
+        assertHasValues('.selected', [14, 15, 16])
+        expect(startLabelValue()).toEqual('Tu 1/14/2014')
+        expect(endLabelValue()).toEqual('Th 1/16/2014')
+      })
     })
 
     describe('calendar events', function() {
@@ -430,6 +440,7 @@ define(function(require) {
         expect(previous.find('.continuousCalendar')).toBeVisible()
         expect(startLabelValue()).toEqual('Su 10/26/2008')
         expect(startFieldValue()).toEqual('10/26/2008')
+        expect(cal().calendarRange()).toEqual(DateTime.fromDate(2008, 10, 26))
       })
 
       it('clearing closes the calendar', function() {
@@ -439,6 +450,14 @@ define(function(require) {
         expect(cal().find('.continuousCalendar')).not.toBeVisible()
         expect(startFieldValue()).toEqual('')
         expect(endFieldValue()).toEqual('')
+      })
+
+      it('changes its selection when opening according to start field value', function() {
+        createPopupCalendar()
+        setStartFieldValue('3/16/2009')
+        cal().find('.calendarIcon').click()
+        assertHasValues('.selected', [16])
+        expect(startLabelValue()).toEqual('Mo 3/16/2009')
       })
     })
 
@@ -639,6 +658,8 @@ define(function(require) {
 
   function createPopupCalendar() { createCalendarFields({startDate: '4/29/2009'}).continuousCalendar({isPopup: true}) }
 
+  function createPopupRangeCalendar(start, end) { createCalendarFields({startDate: '', endDate: ''}).continuousCalendar({firstDate: start, lastDate: end, isPopup: true}) }
+
   function createClearablePopupCalendar() { createCalendarFields({startDate: '7/24/2013'}).continuousCalendar({isPopup: true, allowClearDates: true}) }
 
   function createPopupWeekCalendar() {
@@ -665,7 +686,13 @@ define(function(require) {
 
   function endFieldValue() { return cal().find('input.endDate').val() }
 
+  function endLabelValue() { return cal().find('span.endDateLabel').text() }
+
   function click(selector) { $(selector).click() }
+
+  function setStartFieldValue(value) { return cal().find('input.startDate').val(value) }
+
+  function setEndFieldValue(value) { return cal().find('input.endDate').val(value) }
 
   function assertHasValues(selector, expectedArray) {
     expect($.map(cal().find(selector), function(elem) {


### PR DESCRIPTION
When a popup calendar is opened, the selection
is set according to the start and end fields, if
they have a value
