### PR TITLE
Rename DateParser to DateParse due to consistency

### DIFF
--- a/src/main/DateParse.js
+++ b/src/main/DateParse.js
@@ -1,20 +1,20 @@
 define(function(require) {
   var DateTime = require('./DateTime')
 
-  var DateParser = {}
-  DateParser.parseRegexes = []
-  DateParser.defaultFormat = 'n/j/Y'
+  var DateParse = {}
+  DateParse.parseRegexes = []
+  DateParse.defaultFormat = 'n/j/Y'
 
-  DateParser.parse = function(input, locale) {
+  DateParse.parse = function(input, locale) {
     if(input === 'today') {
       return DateTime.today()
     }
-    var format = locale ? locale.shortDateFormat : DateParser.defaultFormat
-    var date = DateParser.parseDate(input, format)
+    var format = locale ? locale.shortDateFormat : DateParse.defaultFormat
+    var date = DateParse.parseDate(input, format)
     return date ? date : new DateTime(input)
   }
 
-  DateParser.parseDate = function(input, format) {
+  DateParse.parseDate = function(input, format) {
     var values = input.match(getOrCreateParseRegexp())
     return values ? matchesToDateTime(values) : null
 
@@ -31,14 +31,14 @@ define(function(require) {
     }
 
     function getOrCreateParseRegexp() {
-      if(DateParser.parseRegexes[format] === undefined) {
-        DateParser.parseRegexes[format] = new RegExp(format.replace(/[djmnY]/g, '(\\d+)').replace(/\./g, '\\.'))
+      if(DateParse.parseRegexes[format] === undefined) {
+        DateParse.parseRegexes[format] = new RegExp(format.replace(/[djmnY]/g, '(\\d+)').replace(/\./g, '\\.'))
       }
-      return DateParser.parseRegexes[format]
+      return DateParse.parseRegexes[format]
     }
   }
 
-  DateParser.parseTime = function(timeStr) {
+  DateParse.parseTime = function(timeStr) {
     var splittedTime = splitTime(timeStr.replace(/:|,/i, '.'))
     var time = [+(splittedTime[0]), +(splittedTime[1])]
     return (isHour(time[0]) && isMinute(time[1])) ? time : null
@@ -60,5 +60,5 @@ define(function(require) {
     function isHour(hours) { return !isNaN(hours) && hours >= 0 && hours <= 23 }
   }
 
-  return DateParser
+  return DateParse
 })

--- a/src/main/DateRange.js
+++ b/src/main/DateRange.js
@@ -2,7 +2,7 @@ define(function(require) {
   var $ = require('jquery')
   var DateTime = require('./DateTime')
   var DateFormat = require('./DateFormat')
-  var DateParser = require('./DateParser')
+  var DateParse = require('./DateParse')
 
   function DateRange(date1, date2) {
     if(!date1 || !date2) {
@@ -114,8 +114,8 @@ define(function(require) {
   DateRange.prototype.hasEndsOnWeekend = function() { return this.start.isWeekend() || this.end.isWeekend() }
 
   DateRange.prototype.withTimes = function(startTimeStr, endTimeStr) {
-    var parsedStartTime = DateParser.parseTime(startTimeStr)
-    var parsedEndTime = DateParser.parseTime(endTimeStr)
+    var parsedStartTime = DateParse.parseTime(startTimeStr)
+    var parsedEndTime = DateParse.parseTime(endTimeStr)
     var rangeWithTimes = this.clone()
     if(parsedStartTime && parsedEndTime) {
       rangeWithTimes._valid = true

--- a/src/main/SingleDateEvents.js
+++ b/src/main/SingleDateEvents.js
@@ -1,7 +1,7 @@
 define(function(require) {
   var $ = require('jquery')
   var DateFormat = require('./DateFormat')
-  var DateParser = require('./DateParser')
+  var DateParse = require('./DateParse')
 
   return function(container, calendarBody, executeCallback, locale, params, getElemDate, popupBehavior, startDate) {
     return {
@@ -26,7 +26,7 @@ define(function(require) {
       setSelection(fieldDate(params.startField) || startDate)
     }
 
-    function fieldDate(field) { return field.length > 0 && field.val().length > 0 ? DateParser.parse(field.val(), locale) : null }
+    function fieldDate(field) { return field.length > 0 && field.val().length > 0 ? DateParse.parse(field.val(), locale) : null }
 
     function setSelection(date) {
       var selectedDateKey = date && DateFormat.format(date, 'Ymd', locale)

--- a/src/main/jquery.continuousCalendar.js
+++ b/src/main/jquery.continuousCalendar.js
@@ -1,7 +1,7 @@
 define(function(require) {
   var $ = require('jquery')
   var DateFormat = require('./DateFormat')
-  var DateParser = require('./DateParser')
+  var DateParse = require('./DateParse')
   var DateLocale = require('./DateLocale')
   var DateRange = require('./DateRange')
   var DateTime = require('./DateTime')
@@ -107,7 +107,7 @@ define(function(require) {
 
         return  new DateRange(rangeStart, rangeEnd)
 
-        function dateOrWeek(date, week) { return date ? DateParser.parse(date, locale) : firstWeekdayOfGivenDate.plusDays(week)}
+        function dateOrWeek(date, week) { return date ? DateParse.parse(date, locale) : firstWeekdayOfGivenDate.plusDays(week)}
       }
 
       function bindScrollEvent() {
@@ -130,7 +130,7 @@ define(function(require) {
 
       function parseDisabledDates(dates) {
         var dateMap = {}
-        $.each(dates, function(index, date) { dateMap[DateParser.parse(date, locale).date] = true })
+        $.each(dates, function(index, date) { dateMap[DateParse.parse(date, locale).date] = true })
         return dateMap
       }
 
@@ -240,7 +240,7 @@ define(function(require) {
 
       function calculateCellHeight() { averageCellHeight = parseInt(calendarBody.bodyTable.height() / $('tr', calendarBody.bodyTable).size(), 10) }
 
-      function fieldDate(field) { return field.length > 0 && field.val().length > 0 ? DateParser.parse(field.val(), locale) : null }
+      function fieldDate(field) { return field.length > 0 && field.val().length > 0 ? DateParse.parse(field.val(), locale) : null }
 
       function executeCallback(selection) {
         params.callback.call(container, selection)

--- a/src/main/wrapEnd.frag
+++ b/src/main/wrapEnd.frag
@@ -1,6 +1,6 @@
 require('jquery.continuousCalendar')
 window.DateFormat = require('DateFormat')
-window.DateParser = require('DateParser')
+window.DateParse = require('DateParse')
 window.DateLocale = require('DateLocale')
 window.DateTime = require('DateTime')
 window.DateRange = require('DateRange')


### PR DESCRIPTION
Since there is a module named DateFormat (not DatedFormatter), DateParser should be DateParse. 
