### PR TITLE
Updated createSafeDate function for brazil timezone

### DIFF
--- a/build/jquery.continuousCalendar-latest.js
+++ b/build/jquery.continuousCalendar-latest.js
@@ -880,7 +880,7 @@ function createSafeDate(year, month, date, hours, minutes, seconds) {
     month !== newDate.getMonth() + 1 ||
     year !== newDate.getFullYear() ||
     date !== newDate.getDate() ||
-    hours !== newDate.getHours() ||
+    hours !== (newDate.getHours() & newDate.getHours()-1) ||
     minutes !== newDate.getMinutes() ||
     seconds !== newDate.getSeconds()) throw Error('Invalid Date: ' + year + '-' + month + '-' + date + ' ' + hours + ':' + minutes + ':' + seconds)
   return newDate


### PR DESCRIPTION
Prevented date to be invalid when auto daylight saving time updated for UTC-03:00
![calendar1](https://cloud.githubusercontent.com/assets/11541135/22948545/0ff8086a-f2e6-11e6-8cd2-8dfc23c3c5da.png)
![calendar2](https://cloud.githubusercontent.com/assets/11541135/22948546/0ff96e94-f2e6-11e6-8104-ee12a2438bda.png)

